### PR TITLE
Update kde-neon extension

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,10 +74,10 @@ plugs:
   shared-memory:
     private: true
   # QT5 libs
-  kf5-5-108-qt-5-15-10-core22:
-    content: kf5-5-108-qt-5-15-10-core22-all
+  kf5-5-113-qt-5-15-11-core22:
+    content: kf5-5-113-qt-5-15-11-core22-all
     interface: content
-    default-provider: kf5-5-108-qt-5-15-10-core22
+    default-provider: kf5-5-113-qt-5-15-11-core22
     target: $SNAP/kf5
 
 environment:
@@ -252,7 +252,7 @@ parts:
       - elmerfem-csc # FEM
       - openscad  # OpenSCAD
     override-build: |
-      kde_sdk_dir="/snap/kf5-5-108-qt-5-15-10-core22-sdk/current"
+      kde_sdk_dir="/snap/kf5-5-113-qt-5-15-11-core22-sdk/current"
       mkdir -p /etc/xdg/qtchooser
       cp "$kde_sdk_dir/etc/xdg/qtchooser/default.conf" "/etc/xdg/qtchooser/default.conf"
       SHIBOKEN_BIN_PATH="/workspace/usr/bin/shiboken2"
@@ -312,10 +312,10 @@ parts:
   cleanup:
     after: [stub-chown, freecad, python-packages, snap-setup-mod, graphviz]
     plugin: nil
-    build-snaps: [kf5-5-108-qt-5-15-10-core22-sdk]
+    build-snaps: [kf5-5-113-qt-5-15-11-core22-sdk]
     override-prime: |
       set -eux
-      for snap in "kf5-5-108-qt-5-15-10-core22-sdk"; do  # List all content-snaps you're using here
+      for snap in "kf5-5-113-qt-5-15-11-core22-sdk"; do  # List all content-snaps you're using here
         cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$CRAFT_PRIME/{}" "$CRAFT_PRIME/usr/{}" \;
       done
       for cruft in bug lintian man; do


### PR DESCRIPTION
Update to latest platform and build snap versions as described on https://snapcraft.io/docs/kde-neon-extension